### PR TITLE
Print types as parseable annotations

### DIFF
--- a/crates/lzscr-cli/src/main.rs
+++ b/crates/lzscr-cli/src/main.rs
@@ -580,7 +580,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                         }
                         println!("{}", serde_json::to_string_pretty(&TypeOut { ty: t })?);
                     } else if opt.types == "pretty" {
-                        eprintln!("type: {t}");
+                        eprintln!("%{{{}}}", t);
                     }
                 }
                 Err(e) => {

--- a/crates/lzscr-parser/src/lib.rs
+++ b/crates/lzscr-parser/src/lib.rs
@@ -1157,7 +1157,7 @@ pub fn parse_expr(src: &str) -> Result<Expr, ParseError> {
                             // Build arity-specific tuple tag: ".," for 2, ".,," for 3, ...
                             let tag = {
                                 let mut s = String::from(".");
-                                let n_commas = if items.len() > 0 { items.len() - 1 } else { 0 };
+                                let n_commas = if !items.is_empty() { items.len() - 1 } else { 0 };
                                 for _ in 0..n_commas { s.push(','); }
                                 s
                             };
@@ -1223,7 +1223,7 @@ pub fn parse_expr(src: &str) -> Result<Expr, ParseError> {
                             // (., (.KV "k" v) ...) with arity-specific tag
                             let tag = {
                                 let mut s = String::from(".");
-                                let n_commas = if pairs.len() > 0 { pairs.len() - 1 } else { 0 };
+                                let n_commas = if !pairs.is_empty() { pairs.len() - 1 } else { 0 };
                                 for _ in 0..n_commas { s.push(','); }
                                 s
                             };

--- a/crates/lzscr-types/src/lib.rs
+++ b/crates/lzscr-types/src/lib.rs
@@ -1032,8 +1032,7 @@ fn infer_expr(
                                 let s1 = merge_variants(ctx, &mut acc, &t1)?
                                     .compose(merge_variants(ctx, &mut acc, &t2)?);
                                 // Build union type from acc
-                                let variants: Vec<(String, Vec<Type>)> =
-                                    acc.into_iter().map(|(k, v)| (k, v)).collect();
+                                let variants: Vec<(String, Vec<Type>)> = acc.into_iter().collect();
                                 let ret = Type::SumCtor(variants);
                                 let s = s1.compose(se).compose(s_acc);
                                 return Ok((ret.apply(&s), s));
@@ -1613,8 +1612,8 @@ fn pp_type(t: &Type) -> String {
         Type::Bool => "Bool".into(),
         Type::Str => "Str".into(),
         Type::Char => "Char".into(),
-        Type::Var(TvId(i)) => format!("t{i}"),
-        Type::List(a) => format!("List {}", pp_atom(a)),
+        Type::Var(TvId(i)) => format!("%t{i}"),
+        Type::List(a) => format!("[{}]", pp_type(a)),
         Type::Tuple(xs) => format!("({})", xs.iter().map(pp_type).collect::<Vec<_>>().join(", ")),
         Type::Record(fs) => {
             let mut items: Vec<_> =
@@ -1627,14 +1626,14 @@ fn pp_type(t: &Type) -> String {
             if payload.is_empty() {
                 tag.clone()
             } else {
-                format!("{}({})", tag, payload.iter().map(pp_type).collect::<Vec<_>>().join(", "))
+                format!("{} {}", tag, payload.iter().map(pp_atom).collect::<Vec<_>>().join(" "))
             }
         }
         Type::Named { name, args } => {
             if args.is_empty() {
                 name.clone()
             } else {
-                format!("{}<{}>", name, args.iter().map(pp_type).collect::<Vec<_>>().join(", "))
+                format!("{} {}", name, args.iter().map(pp_atom).collect::<Vec<_>>().join(" "))
             }
         }
         Type::SumCtor(vs) => {
@@ -1644,7 +1643,7 @@ fn pp_type(t: &Type) -> String {
                     if ps.is_empty() {
                         t.clone()
                     } else {
-                        format!("{}({})", t, ps.iter().map(pp_type).collect::<Vec<_>>().join(", "))
+                        format!("{} {}", t, ps.iter().map(pp_atom).collect::<Vec<_>>().join(" "))
                     }
                 })
                 .collect::<Vec<_>>()

--- a/crates/lzscr-types/tests/type_display.rs
+++ b/crates/lzscr-types/tests/type_display.rs
@@ -1,0 +1,19 @@
+use lzscr_types::api::infer_program;
+
+#[test]
+fn id_function_type() {
+    let t = infer_program("\\~x -> ~x").unwrap();
+    assert_eq!(t, "%t0 -> %t0");
+}
+
+#[test]
+fn list_int_type() {
+    let t = infer_program("[1,2]").unwrap();
+    assert_eq!(t, "[Int]");
+}
+
+#[test]
+fn ctor_application_type() {
+    let t = infer_program(".Foo 1").unwrap();
+    assert_eq!(t, ".Foo Int");
+}


### PR DESCRIPTION
## Summary
- pretty-print inferred types in the language's own syntax so they can be parsed back
- show inferred types as `%{Type}` annotations when `--types pretty` is enabled
- add tests for the new type printer and clean up parser `len()==0` checks

## Testing
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68bee57785408327a1f2f45ad354b3af