### PR TITLE
feat: remove primitive Bool; adopt union constructors and nightly udeps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,12 +128,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@nightly
       - name: Cache cargo
         uses: Swatinem/rust-cache@v2
-      - name: Install cargo-udeps
-        uses: taiki-e/install-action@v2
-        with:
-          tool: cargo-udeps
+      - name: Install cargo-udeps (nightly)
+        run: cargo +nightly install cargo-udeps --locked
       - name: Run cargo udeps
-        run: cargo udeps --all-targets
+        run: cargo +nightly udeps --all-targets --all-features

--- a/crates/lzscr-analyzer/src/lib.rs
+++ b/crates/lzscr-analyzer/src/lib.rs
@@ -42,33 +42,29 @@ pub fn analyze_duplicates(expr: &Expr, opt: AnalyzeOptions) -> Vec<DupFinding> {
                 h.write_u8(7);
                 h.write_i32(*c);
             }
-            Bool(b) => {
-                h.write_u8(8);
-                h.write_u8(*b as u8);
-            }
             TypeBind { pat, .. } => {
-                h.write_u8(9);
+                h.write_u8(8);
                 hash_pattern_shape(pat, h);
             }
             Var(_) => {
-                h.write_u8(10);
+                h.write_u8(9);
             }
             Tuple(xs) => {
-                h.write_u8(11);
+                h.write_u8(10);
                 h.write_usize(xs.len());
                 for x in xs {
                     hash_pattern_shape(x, h);
                 }
             }
             List(xs) => {
-                h.write_u8(12);
+                h.write_u8(11);
                 h.write_usize(xs.len());
                 for x in xs {
                     hash_pattern_shape(x, h);
                 }
             }
             Record(fs) => {
-                h.write_u8(13);
+                h.write_u8(12);
                 h.write_usize(fs.len());
                 for (k, v) in fs {
                     h.write(k.as_bytes());
@@ -76,7 +72,7 @@ pub fn analyze_duplicates(expr: &Expr, opt: AnalyzeOptions) -> Vec<DupFinding> {
                 }
             }
             Ctor { name, args } => {
-                h.write_u8(14);
+                h.write_u8(13);
                 h.write(name.as_bytes());
                 h.write_usize(args.len());
                 for a in args {
@@ -84,12 +80,12 @@ pub fn analyze_duplicates(expr: &Expr, opt: AnalyzeOptions) -> Vec<DupFinding> {
                 }
             }
             Cons(hd, tl) => {
-                h.write_u8(15);
+                h.write_u8(14);
                 hash_pattern_shape(hd, h);
                 hash_pattern_shape(tl, h);
             }
             As(a, b) => {
-                h.write_u8(16);
+                h.write_u8(15);
                 hash_pattern_shape(a, h);
                 hash_pattern_shape(b, h);
             }

--- a/crates/lzscr-analyzer/src/lib.rs
+++ b/crates/lzscr-analyzer/src/lib.rs
@@ -474,8 +474,7 @@ pub fn analyze_unbound_refs(expr: &Expr, allowlist: &HashSet<String>) -> Vec<Unb
                         | PatternKind::Int(_)
                         | PatternKind::Float(_)
                         | PatternKind::Str(_)
-                        | PatternKind::Char(_)
-                        | PatternKind::Bool(_) => {}
+                        | PatternKind::Char(_) => {}
                         PatternKind::TypeBind { pat, .. } => {
                             binds(pat, acc);
                         }
@@ -555,8 +554,7 @@ pub fn analyze_unbound_refs(expr: &Expr, allowlist: &HashSet<String>) -> Vec<Unb
                         | PatternKind::Int(_)
                         | PatternKind::Float(_)
                         | PatternKind::Str(_)
-                        | PatternKind::Char(_)
-                        | PatternKind::Bool(_) => {}
+                        | PatternKind::Char(_) => {}
                         PatternKind::TypeBind { pat, .. } => {
                             binds(pat, acc);
                         }
@@ -624,8 +622,7 @@ pub fn analyze_shadowing(expr: &Expr) -> Vec<Shadowing> {
                         | PatternKind::Int(_)
                         | PatternKind::Float(_)
                         | PatternKind::Str(_)
-                        | PatternKind::Char(_)
-                        | PatternKind::Bool(_) => {}
+                        | PatternKind::Char(_) => {}
                         PatternKind::TypeBind { pat, .. } => {
                             pat_idents(pat, out);
                         }
@@ -690,8 +687,7 @@ pub fn analyze_shadowing(expr: &Expr) -> Vec<Shadowing> {
                         | PatternKind::Int(_)
                         | PatternKind::Float(_)
                         | PatternKind::Str(_)
-                        | PatternKind::Char(_)
-                        | PatternKind::Bool(_) => {}
+                        | PatternKind::Char(_) => {}
                         PatternKind::TypeBind { pat, .. } => {
                             pat_idents(pat, outn);
                         }
@@ -797,8 +793,7 @@ pub fn analyze_unused_params(expr: &Expr) -> Vec<UnusedParam> {
             | PatternKind::Int(_)
             | PatternKind::Float(_)
             | PatternKind::Str(_)
-            | PatternKind::Char(_)
-            | PatternKind::Bool(_) => false,
+            | PatternKind::Char(_) => false,
             PatternKind::TypeBind { pat, .. } => binds_param(pat, name),
             PatternKind::Var(n) => n == name,
             PatternKind::Tuple(xs) => xs.iter().any(|x| binds_param(x, name)),
@@ -821,8 +816,7 @@ pub fn analyze_unused_params(expr: &Expr) -> Vec<UnusedParam> {
                         | PatternKind::Int(_)
                         | PatternKind::Float(_)
                         | PatternKind::Str(_)
-                        | PatternKind::Char(_)
-                        | PatternKind::Bool(_) => {}
+                        | PatternKind::Char(_) => {}
                         PatternKind::TypeBind { pat, .. } => {
                             collect(pat, outn);
                         }

--- a/crates/lzscr-ast/src/lib.rs
+++ b/crates/lzscr-ast/src/lib.rs
@@ -91,6 +91,8 @@ pub mod ast {
         Char(i32),
         Ref(String),    // ~name
         Symbol(String), // bare symbol (constructor var candidate)
+        // Record literal: { k1: e1, k2: e2, ... }
+        Record(Vec<(String, Expr)>),
         // Type annotation: %{T} e (identity)
         Annot { ty: TypeExpr, expr: Box<Expr> },
         // First-class type value: %{T}
@@ -190,6 +192,14 @@ pub mod pretty {
             }
             ExprKind::Ref(n) => format!("~{n}"),
             ExprKind::Symbol(s) => s.clone(),
+            ExprKind::Record(fields) => {
+                let inner = fields
+                    .iter()
+                    .map(|(k, v)| format!("{k}: {}", print_expr(v)))
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                format!("{{ {inner} }}")
+            }
             ExprKind::Annot { ty, expr } => {
                 format!("%{{{}}} {}", print_type(ty), print_expr(expr))
             }

--- a/crates/lzscr-ast/src/lib.rs
+++ b/crates/lzscr-ast/src/lib.rs
@@ -61,7 +61,6 @@ pub mod ast {
         Float(f64),
         Str(String),
         Char(i32),
-        Bool(bool),
         Record(Vec<(String, Pattern)>), // { k: p, ... }
         As(Box<Pattern>, Box<Pattern>), // p1 @ p2
         // List patterns
@@ -158,7 +157,6 @@ pub mod pretty {
                 tmp.push(ch);
                 format!("'{}'", tmp.escape_default())
             }
-            PatternKind::Bool(b) => format!("{}", b),
             PatternKind::Record(fields) => {
                 let inner = fields
                     .iter()

--- a/crates/lzscr-cli/src/main.rs
+++ b/crates/lzscr-cli/src/main.rs
@@ -770,7 +770,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 Value::Unit => "()".into(),
                 Value::Int(n) => n.to_string(),
                 Value::Float(f) => f.to_string(),
-                Value::Bool(b) => b.to_string(),
                 Value::Str(s) => s.to_string(),
                 Value::Char(c) => char_literal_string(*c),
                 Value::Symbol(id) => env.symbol_name(*id),

--- a/crates/lzscr-cli/src/main.rs
+++ b/crates/lzscr-cli/src/main.rs
@@ -1035,7 +1035,6 @@ fn rebase_pattern_with_minus(p: &Pattern, add: usize, minus: usize) -> Pattern {
         Float(f) => Float(*f),
         Str(s) => Str(s.clone()),
         Char(c) => Char(*c),
-        Bool(b) => Bool(*b),
         Record(fields) => {
             let mut new = Vec::with_capacity(fields.len());
             for (k, v) in fields.iter() {

--- a/crates/lzscr-cli/src/main.rs
+++ b/crates/lzscr-cli/src/main.rs
@@ -645,7 +645,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                         match e {
                             TypeError::Mismatch { span_offset, span_len, .. }
                             | TypeError::EffectNotAllowed { span_offset, span_len }
-                                | TypeError::UnboundRef { span_offset, span_len, .. }
+                            | TypeError::UnboundRef { span_offset, span_len, .. }
                             | TypeError::MixedAltBranches { span_offset, span_len } => {
                                 eprintln!("type error: {}", e);
                                 let block = src_reg.format_span_block(span_offset, span_len);
@@ -1156,7 +1156,7 @@ fn node_kind_name(k: &ExprKind) -> &'static str {
         ExprKind::Apply { .. } => "Apply",
         ExprKind::Block(_) => "Block",
         ExprKind::List(_) => "List",
-    ExprKind::Record(_) => "Record",
+        ExprKind::Record(_) => "Record",
         ExprKind::LetGroup { .. } => "LetGroup",
         ExprKind::Raise(_) => "Raise",
         ExprKind::AltLambda { .. } => "AltLambda",

--- a/crates/lzscr-cli/src/main.rs
+++ b/crates/lzscr-cli/src/main.rs
@@ -645,7 +645,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                         match e {
                             TypeError::Mismatch { span_offset, span_len, .. }
                             | TypeError::EffectNotAllowed { span_offset, span_len }
-                            | TypeError::UnboundRef { span_offset, span_len, .. } => {
+                                | TypeError::UnboundRef { span_offset, span_len, .. }
+                            | TypeError::MixedAltBranches { span_offset, span_len } => {
                                 eprintln!("type error: {}", e);
                                 let block = src_reg.format_span_block(span_offset, span_len);
                                 eprintln!("{}", block);
@@ -670,7 +671,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                             match e {
                                 TypeError::Mismatch { span_offset, span_len, .. }
                                 | TypeError::EffectNotAllowed { span_offset, span_len }
-                                | TypeError::UnboundRef { span_offset, span_len, .. } => {
+                                | TypeError::UnboundRef { span_offset, span_len, .. }
+                                | TypeError::MixedAltBranches { span_offset, span_len } => {
                                     eprintln!("type error: {}", e);
                                     let block = src_reg.format_span_block(span_offset, span_len);
                                     eprintln!("{}", block);
@@ -703,7 +705,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                             match e {
                                 TypeError::Mismatch { span_offset, span_len, .. }
                                 | TypeError::EffectNotAllowed { span_offset, span_len }
-                                | TypeError::UnboundRef { span_offset, span_len, .. } => {
+                                | TypeError::UnboundRef { span_offset, span_len, .. }
+                                | TypeError::MixedAltBranches { span_offset, span_len } => {
                                     eprintln!("type error: {}", e);
                                     let block = src_reg.format_span_block(span_offset, span_len);
                                     eprintln!("{}", block);

--- a/crates/lzscr-coreir/src/lib.rs
+++ b/crates/lzscr-coreir/src/lib.rs
@@ -343,7 +343,7 @@ fn eval_builtin(name: &str, args: &[IrValue]) -> Result<IrValue, IrEvalError> {
             Err(IrEvalError::Arity("div by zero".into()))
         }
         ("div", [IrValue::Int(a), IrValue::Int(b)]) => Ok(IrValue::Int(a / b)),
-    ("to_str", [v]) => Ok(IrValue::Str(match v {
+        ("to_str", [v]) => Ok(IrValue::Str(match v {
             IrValue::Unit => "()".into(),
             IrValue::Int(n) => n.to_string(),
             IrValue::Float(f) => f.to_string(),
@@ -407,7 +407,7 @@ fn eval_term_with_env(
         Op::Unit => Ok(IrValue::Unit),
         Op::Int(n) => Ok(IrValue::Int(*n)),
         Op::Float(f) => Ok(IrValue::Float(*f)),
-    Op::Bool(b) => Ok(IrValue::Str(if *b { ".True".into() } else { ".False".into() })),
+        Op::Bool(b) => Ok(IrValue::Str(if *b { ".True".into() } else { ".False".into() })),
         Op::Str(s) => Ok(IrValue::Str(s.clone())),
         Op::Char(c) => Ok(IrValue::Char(*c)),
         Op::Ref(n) => {
@@ -457,7 +457,7 @@ pub fn print_ir_value(v: &IrValue) -> String {
     match v {
         IrValue::Unit => "()".into(),
         IrValue::Int(n) => n.to_string(),
-    IrValue::Float(f) => f.to_string(),
+        IrValue::Float(f) => f.to_string(),
         IrValue::Str(s) => s.clone(),
         IrValue::Char(c) => {
             let ch = char::from_u32(*c as u32).unwrap_or('\u{FFFD}');

--- a/crates/lzscr-parser/src/lib.rs
+++ b/crates/lzscr-parser/src/lib.rs
@@ -1179,8 +1179,8 @@ pub fn parse_expr(src: &str) -> Result<Expr, ParseError> {
                     if matches!(nxt.tok, Tok::RBrace) {
                         let r = bump(i, toks).unwrap();
                         let span_all = Span::new(t.span.offset, r.span.offset + r.span.len - t.span.offset);
-                        // empty application of (.Record)
-                        return Ok(Expr::new(ExprKind::Apply { func: Box::new(Expr::new(ExprKind::Ref("Record".into()), t.span)), arg: Box::new(Expr::new(ExprKind::Unit, r.span)) }, span_all));
+                        // empty record: (.Record .)
+                        return Ok(Expr::new(ExprKind::Apply { func: Box::new(Expr::new(ExprKind::Symbol(".Record".into()), t.span)), arg: Box::new(Expr::new(ExprKind::Symbol(".".into()), r.span)) }, span_all));
                     }
                 }
                 let mut pairs: Vec<(String, Expr)> = Vec::new();
@@ -1229,13 +1229,13 @@ pub fn parse_expr(src: &str) -> Result<Expr, ParseError> {
                             };
                             let mut tuple_expr = Expr::new(ExprKind::Symbol(tag), t.span);
                             for (k, v) in pairs {
-                                let kv = Expr::new(ExprKind::Apply { func: Box::new(Expr::new(ExprKind::Ref("KV".into()), t.span)), arg: Box::new(Expr::new(ExprKind::Str(k), t.span)) }, t.span);
+                                let kv = Expr::new(ExprKind::Apply { func: Box::new(Expr::new(ExprKind::Symbol(".KV".into()), t.span)), arg: Box::new(Expr::new(ExprKind::Str(k), t.span)) }, t.span);
                                 let kv2 = Expr::new(ExprKind::Apply { func: Box::new(kv), arg: Box::new(v) }, t.span);
                                 let sp = Span::new(tuple_expr.span.offset, span_all.offset + span_all.len - tuple_expr.span.offset);
                                 tuple_expr = Expr::new(ExprKind::Apply { func: Box::new(tuple_expr), arg: Box::new(kv2) }, sp);
                             }
                             // (.Record (., ...))
-                            let expr = Expr::new(ExprKind::Apply { func: Box::new(Expr::new(ExprKind::Ref("Record".into()), t.span)), arg: Box::new(tuple_expr) }, span_all);
+                            let expr = Expr::new(ExprKind::Apply { func: Box::new(Expr::new(ExprKind::Symbol(".Record".into()), t.span)), arg: Box::new(tuple_expr) }, span_all);
                             return Ok(expr);
                         }
                         _ => return Err(ParseError::Generic("expected , or }".into())),

--- a/crates/lzscr-parser/src/lib.rs
+++ b/crates/lzscr-parser/src/lib.rs
@@ -348,20 +348,16 @@ pub fn parse_expr(src: &str) -> Result<Expr, ParseError> {
                         _ => break,
                     }
                 }
-                if args.is_empty() && (m == ".True" || m == ".False") {
-                    Pattern::new(PatternKind::Bool(m == ".True"), h.span)
+                let end = if args.is_empty() {
+                    h.span.offset + h.span.len
                 } else {
-                    let end = if args.is_empty() {
-                        h.span.offset + h.span.len
-                    } else {
-                        let last = args.last().unwrap();
-                        last.span.offset + last.span.len
-                    };
-                    Pattern::new(
-                        PatternKind::Ctor { name: m.clone(), args },
-                        Span::new(h.span.offset, end - h.span.offset),
-                    )
-                }
+                    let last = args.last().unwrap();
+                    last.span.offset + last.span.len
+                };
+                Pattern::new(
+                    PatternKind::Ctor { name: m.clone(), args },
+                    Span::new(h.span.offset, end - h.span.offset),
+                )
             }
             _ => {
                 return Err(ParseError::WithSpan {

--- a/crates/lzscr-parser/src/lib.rs
+++ b/crates/lzscr-parser/src/lib.rs
@@ -37,58 +37,38 @@ pub fn parse_expr(src: &str) -> Result<Expr, ParseError> {
     }
 
     // Pattern parsing -----------------------------------------------------
-    fn parse_pat_atom<'a>(
-        i: &mut usize,
-        toks: &'a [lzscr_lexer::Lexed<'a>],
-    ) -> Result<Pattern, ParseError> {
-        let t =
-            bump(i, toks).ok_or_else(|| ParseError::Generic("unexpected EOF in pattern".into()))?;
+    fn parse_pat_atom<'a>(i: &mut usize, toks: &'a [lzscr_lexer::Lexed<'a>]) -> Result<Pattern, ParseError> {
+        let t = bump(i, toks)
+            .ok_or_else(|| ParseError::Generic("unexpected EOF in pattern".into()))?;
         let pat = match &t.tok {
             Tok::TypeOpen => {
-                // Pattern-level type binder: %{ %a, %b, ... } pat
-                // Close token is '}' (RBrace)
                 let start_off = t.span.offset;
                 let mut tvars: Vec<String> = Vec::new();
-                // Allow empty binder list: %{ } pat
                 loop {
-                    // If next is '}', end binder list
                     if let Some(nxt) = peek(*i, toks) {
                         if matches!(nxt.tok, Tok::RBrace) {
-                            let _ = bump(i, toks); // consume '}'
+                            let _ = bump(i, toks);
                             break;
                         }
                     } else {
-                        return Err(ParseError::Generic(
-                            "} expected to close %{ in pattern".into(),
-                        ));
+                        return Err(ParseError::WithSpan { msg: "} expected to close %{ in pattern".into(), span_offset: t.span.offset, span_len: t.span.len });
                     }
-                    // Expect a type var like %a
-                    let tv = bump(i, toks).ok_or_else(|| {
-                        ParseError::Generic("expected %a in %{ ... } pattern binder".into())
-                    })?;
+                    let tv = bump(i, toks).ok_or_else(|| ParseError::WithSpan { msg: "expected %a in %{ ... } pattern binder".into(), span_offset: t.span.offset, span_len: t.span.len })?;
                     match &tv.tok {
                         Tok::TyVar(name) => tvars.push(name.clone()),
                         _ => {
-                            return Err(ParseError::Generic(
-                                "expected %a in %{ ... } pattern binder".into(),
-                            ))
+                            return Err(ParseError::WithSpan { msg: "expected %a in %{ ... } pattern binder".into(), span_offset: tv.span.offset, span_len: tv.span.len });
                         }
                     }
-                    // Next must be ',' or '}'
-                    let sep = bump(i, toks).ok_or_else(|| {
-                        ParseError::Generic(", or } expected in %{ ... } pattern binder".into())
-                    })?;
+                    let sep = bump(i, toks).ok_or_else(|| ParseError::WithSpan { msg: ", or } expected in %{ ... } pattern binder".into(), span_offset: t.span.offset, span_len: t.span.len })?;
                     match sep.tok {
                         Tok::Comma => continue,
                         Tok::RBrace => break,
                         _ => {
-                            return Err(ParseError::Generic(
-                                ", or } expected in %{ ... } pattern binder".into(),
-                            ))
+                            return Err(ParseError::WithSpan { msg: ", or } expected in %{ ... } pattern binder".into(), span_offset: sep.span.offset, span_len: sep.span.len });
                         }
                     }
                 }
-                // After binder, require a pattern
                 let inner = parse_pattern(i, toks)?;
                 let end_off = inner.span.offset + inner.span.len;
                 Pattern::new(
@@ -97,173 +77,108 @@ pub fn parse_expr(src: &str) -> Result<Expr, ParseError> {
                 )
             }
             Tok::Tilde => {
-                let id = bump(i, toks).ok_or_else(|| {
-                    ParseError::Generic("expected ident after ~ in pattern".into())
-                })?;
+                let id = bump(i, toks).ok_or_else(|| ParseError::WithSpan { msg: "expected ident after ~ in pattern".into(), span_offset: t.span.offset, span_len: t.span.len })?;
                 match id.tok {
                     Tok::Ident => Pattern::new(
                         PatternKind::Var(id.text.to_string()),
                         Span::new(t.span.offset, id.span.offset + id.span.len - t.span.offset),
                     ),
-                    _ => {
-                        return Err(ParseError::Generic("expected ident after ~ in pattern".into()))
-                    }
+                    _ => return Err(ParseError::WithSpan { msg: "expected ident after ~ in pattern".into(), span_offset: id.span.offset, span_len: id.span.len }),
                 }
             }
             Tok::LParen => {
-                // () or (p) or (p1, p2, ...)
                 if let Some(nxt) = peek(*i, toks) {
                     if matches!(nxt.tok, Tok::RParen) {
                         let r = bump(i, toks).unwrap();
-                        return Ok(Pattern::new(
-                            PatternKind::Unit,
-                            Span::new(t.span.offset, r.span.offset + r.span.len - t.span.offset),
-                        ));
+                        return Ok(Pattern::new(PatternKind::Unit, Span::new(t.span.offset, r.span.offset + r.span.len - t.span.offset)));
                     }
                 } else {
-                    return Err(ParseError::Generic(") expected".into()));
+                    return Err(ParseError::WithSpan { msg: ") expected".into(), span_offset: t.span.offset, span_len: t.span.len });
                 }
                 let first = parse_pattern(i, toks)?;
                 if let Some(n2) = peek(*i, toks) {
                     if matches!(n2.tok, Tok::Comma) {
-                        let _ = bump(i, toks); // consume ','
+                        let _ = bump(i, toks);
                         let mut items = vec![first];
                         loop {
                             let p2 = parse_pattern(i, toks)?;
                             items.push(p2);
-                            let sep = bump(i, toks).ok_or_else(|| {
-                                ParseError::Generic(") expected in tuple pattern".into())
-                            })?;
+                            let sep = bump(i, toks).ok_or_else(|| ParseError::WithSpan { msg: ") expected in tuple pattern".into(), span_offset: t.span.offset, span_len: t.span.len })?;
                             match sep.tok {
                                 Tok::Comma => continue,
                                 Tok::RParen => break,
-                                _ => {
-                                    return Err(ParseError::Generic(
-                                        "expected , or ) in tuple pattern".into(),
-                                    ))
-                                }
+                                _ => return Err(ParseError::WithSpan { msg: "expected , or ) in tuple pattern".into(), span_offset: sep.span.offset, span_len: sep.span.len }),
                             }
                         }
-                        let end = toks
-                            .get(*i - 1)
-                            .map(|r| r.span.offset + r.span.len)
-                            .unwrap_or(t.span.offset + t.span.len);
-                        Pattern::new(
-                            PatternKind::Tuple(items),
-                            Span::new(t.span.offset, end - t.span.offset),
-                        )
+                        let end = toks.get(*i - 1).map(|r| r.span.offset + r.span.len).unwrap_or(t.span.offset + t.span.len);
+                        Pattern::new(PatternKind::Tuple(items), Span::new(t.span.offset, end - t.span.offset))
                     } else if matches!(n2.tok, Tok::RParen) {
                         let rp = bump(i, toks).unwrap();
                         let mut p = first;
-                        p.span =
-                            Span::new(t.span.offset, rp.span.offset + rp.span.len - t.span.offset);
+                        p.span = Span::new(t.span.offset, rp.span.offset + rp.span.len - t.span.offset);
                         p
                     } else {
-                        return Err(ParseError::Generic(
-                            "expected , or ) in tuple/group pattern".into(),
-                        ));
+                        return Err(ParseError::WithSpan { msg: "expected , or ) in tuple/group pattern".into(), span_offset: n2.span.offset, span_len: n2.span.len });
                     }
                 } else {
-                    return Err(ParseError::Generic(") expected".into()));
+                    return Err(ParseError::WithSpan { msg: ") expected".into(), span_offset: t.span.offset, span_len: t.span.len });
                 }
             }
             Tok::LBracket => {
-                // [p1, p2, ...]
                 if let Some(nxt) = peek(*i, toks) {
                     if matches!(nxt.tok, Tok::RBracket) {
                         let r = bump(i, toks).unwrap();
-                        Pattern::new(
-                            PatternKind::List(vec![]),
-                            Span::new(t.span.offset, r.span.offset + r.span.len - t.span.offset),
-                        )
+                        Pattern::new(PatternKind::List(vec![]), Span::new(t.span.offset, r.span.offset + r.span.len - t.span.offset))
                     } else {
                         let mut items = Vec::new();
                         loop {
                             let p = parse_pattern(i, toks)?;
                             items.push(p);
-                            let sep = bump(i, toks).ok_or_else(|| {
-                                ParseError::Generic("] or , expected in list pattern".into())
-                            })?;
+                            let sep = bump(i, toks).ok_or_else(|| ParseError::WithSpan { msg: "] or , expected in list pattern".into(), span_offset: t.span.offset, span_len: t.span.len })?;
                             match sep.tok {
                                 Tok::Comma => continue,
                                 Tok::RBracket => break,
-                                _ => {
-                                    return Err(ParseError::Generic(
-                                        "expected , or ] in list pattern".into(),
-                                    ))
-                                }
+                                _ => return Err(ParseError::WithSpan { msg: "expected , or ] in list pattern".into(), span_offset: sep.span.offset, span_len: sep.span.len }),
                             }
                         }
-                        let end = toks
-                            .get(*i - 1)
-                            .map(|r| r.span.offset + r.span.len)
-                            .unwrap_or(t.span.offset + t.span.len);
-                        Pattern::new(
-                            PatternKind::List(items),
-                            Span::new(t.span.offset, end - t.span.offset),
-                        )
+                        let end = toks.get(*i - 1).map(|r| r.span.offset + r.span.len).unwrap_or(t.span.offset + t.span.len);
+                        Pattern::new(PatternKind::List(items), Span::new(t.span.offset, end - t.span.offset))
                     }
                 } else {
-                    return Err(ParseError::Generic("] expected".into()));
+                    return Err(ParseError::WithSpan { msg: "] expected".into(), span_offset: t.span.offset, span_len: t.span.len });
                 }
             }
             Tok::LBrace => {
-                // { k: p, ... }
                 if let Some(nxt) = peek(*i, toks) {
                     if matches!(nxt.tok, Tok::RBrace) {
                         let r = bump(i, toks).unwrap();
-                        Pattern::new(
-                            PatternKind::Record(vec![]),
-                            Span::new(t.span.offset, r.span.offset + r.span.len - t.span.offset),
-                        )
+                        Pattern::new(PatternKind::Record(vec![]), Span::new(t.span.offset, r.span.offset + r.span.len - t.span.offset))
                     } else {
                         let mut fields: Vec<(String, Pattern)> = Vec::new();
                         loop {
-                            let k = bump(i, toks).ok_or_else(|| {
-                                ParseError::Generic("expected key in record pattern".into())
-                            })?;
+                            let k = bump(i, toks).ok_or_else(|| ParseError::WithSpan { msg: "expected key in record pattern".into(), span_offset: t.span.offset, span_len: t.span.len })?;
                             let key = match &k.tok {
                                 Tok::Ident => k.text.to_string(),
-                                _ => {
-                                    return Err(ParseError::Generic(
-                                        "expected ident key in record pattern".into(),
-                                    ))
-                                }
+                                _ => return Err(ParseError::WithSpan { msg: "expected ident key in record pattern".into(), span_offset: k.span.offset, span_len: k.span.len }),
                             };
-                            let col = bump(i, toks).ok_or_else(|| {
-                                ParseError::Generic(": expected after key in record pattern".into())
-                            })?;
+                            let col = bump(i, toks).ok_or_else(|| ParseError::WithSpan { msg: ": expected after key in record pattern".into(), span_offset: t.span.offset, span_len: t.span.len })?;
                             if !matches!(col.tok, Tok::Colon) {
-                                return Err(ParseError::Generic(
-                                    ": expected after key in record pattern".into(),
-                                ));
+                                return Err(ParseError::WithSpan { msg: ": expected after key in record pattern".into(), span_offset: col.span.offset, span_len: col.span.len });
                             }
                             let p = parse_pattern(i, toks)?;
                             fields.push((key, p));
-                            let sep = bump(i, toks).ok_or_else(|| {
-                                ParseError::Generic(", or } expected in record pattern".into())
-                            })?;
+                            let sep = bump(i, toks).ok_or_else(|| ParseError::WithSpan { msg: ", or } expected in record pattern".into(), span_offset: t.span.offset, span_len: t.span.len })?;
                             match sep.tok {
                                 Tok::Comma => continue,
                                 Tok::RBrace => break,
-                                _ => {
-                                    return Err(ParseError::Generic(
-                                        "expected , or } in record pattern".into(),
-                                    ))
-                                }
+                                _ => return Err(ParseError::WithSpan { msg: "expected , or } in record pattern".into(), span_offset: sep.span.offset, span_len: sep.span.len }),
                             }
                         }
-                        let end = toks
-                            .get(*i - 1)
-                            .map(|r| r.span.offset + r.span.len)
-                            .unwrap_or(t.span.offset + t.span.len);
-                        Pattern::new(
-                            PatternKind::Record(fields),
-                            Span::new(t.span.offset, end - t.span.offset),
-                        )
+                        let end = toks.get(*i - 1).map(|r| r.span.offset + r.span.len).unwrap_or(t.span.offset + t.span.len);
+                        Pattern::new(PatternKind::Record(fields), Span::new(t.span.offset, end - t.span.offset))
                     }
                 } else {
-                    return Err(ParseError::Generic("} expected".into()));
+                    return Err(ParseError::WithSpan { msg: "} expected".into(), span_offset: t.span.offset, span_len: t.span.len });
                 }
             }
             Tok::Int(n) => Pattern::new(PatternKind::Int(*n), t.span),
@@ -276,7 +191,7 @@ pub fn parse_expr(src: &str) -> Result<Expr, ParseError> {
                 } else if t.text == "_" {
                     Pattern::new(PatternKind::Wildcard, t.span)
                 } else {
-                    return Err(ParseError::Generic("invalid bare identifier in pattern".into()));
+                    return Err(ParseError::WithSpan { msg: "invalid bare identifier in pattern".into(), span_offset: t.span.offset, span_len: t.span.len });
                 }
             }
             Tok::Member(m) => {
@@ -286,34 +201,17 @@ pub fn parse_expr(src: &str) -> Result<Expr, ParseError> {
                     let Some(nxt) = toks.get(*i) else { break };
                     match nxt.tok {
                         Tok::Arrow | Tok::RParen | Tok::Comma | Tok::Eq | Tok::Semicolon => break,
-                        Tok::Tilde
-                        | Tok::Ident
-                        | Tok::Member(_)
-                        | Tok::LBracket
-                        | Tok::LBrace
-                        | Tok::LParen
-                        | Tok::Int(_)
-                        | Tok::Float(_)
-                        | Tok::Str(_)
-                        | Tok::Char(_) => {
+                        Tok::Tilde | Tok::Ident | Tok::Member(_) | Tok::LBracket | Tok::LBrace | Tok::LParen | Tok::Int(_) | Tok::Float(_) | Tok::Str(_) | Tok::Char(_) => {
                             let a = parse_pat_atom(i, toks)?;
                             args.push(a);
                         }
                         _ => break,
                     }
                 }
-                let end = if args.is_empty() {
-                    h.span.offset + h.span.len
-                } else {
-                    let last = args.last().unwrap();
-                    last.span.offset + last.span.len
-                };
-                Pattern::new(
-                    PatternKind::Ctor { name: m.clone(), args },
-                    Span::new(h.span.offset, end - h.span.offset),
-                )
+                let end = if args.is_empty() { h.span.offset + h.span.len } else { let last = args.last().unwrap(); last.span.offset + last.span.len };
+                Pattern::new(PatternKind::Ctor { name: m.clone(), args }, Span::new(h.span.offset, end - h.span.offset))
             }
-            _ => return Err(ParseError::Generic("unexpected token in pattern".into())),
+            _ => return Err(ParseError::WithSpan { msg: "unexpected token in pattern".into(), span_offset: t.span.offset, span_len: t.span.len }),
         };
         Ok(pat)
     }
@@ -1368,14 +1266,7 @@ pub fn parse_expr(src: &str) -> Result<Expr, ParseError> {
                         lhs.span.offset,
                         arg.span.offset + arg.span.len - lhs.span.offset,
                     );
-                    // sugar: true() / false()  =>  ~true / ~false
-                    if let ExprKind::Symbol(name) = &lhs.kind {
-                        if matches!(arg.kind, ExprKind::Unit) && (name == "true" || name == "false")
-                        {
-                            lhs = Expr::new(ExprKind::Ref(name.clone()), span);
-                            continue;
-                        }
-                    }
+                    // (legacy boolean call sugar removed)
                     lhs = Expr::new(
                         ExprKind::Apply { func: Box::new(lhs), arg: Box::new(arg) },
                         span,

--- a/crates/lzscr-runtime/src/lib.rs
+++ b/crates/lzscr-runtime/src/lib.rs
@@ -201,14 +201,12 @@ impl Env {
     pub fn with_builtins() -> Self {
         let mut e = Env::new();
 
-        // Inject ~true / ~false as references
-        e.vars.insert("true".into(), Value::Bool(true));
-        e.vars.insert("false".into(), Value::Bool(false));
-        e.declare_ctor_arity(".true", 0);
-        e.declare_ctor_arity(".false", 0);
-        // Pre-intern commonly used symbols
-        let _ = e.intern_symbol("True");
-        let _ = e.intern_symbol("False");
+    // Bool via constructors .True / .False (no legacy ~true/~false refs)
+    e.declare_ctor_arity(".True", 0);
+    e.declare_ctor_arity(".False", 0);
+    // Pre-intern commonly used symbols
+    let _ = e.intern_symbol(".True");
+    let _ = e.intern_symbol(".False");
         let _ = e.intern_symbol(".print");
         let _ = e.intern_symbol(".println");
         let _ = e.intern_symbol(".,");

--- a/crates/lzscr-runtime/src/lib.rs
+++ b/crates/lzscr-runtime/src/lib.rs
@@ -217,8 +217,12 @@ impl Env {
                 arity: 1,
                 args: vec![],
                 f: |env, args| match &args[0] {
-                    Value::Symbol(id) if env.symbol_name(*id) == ".True" => Ok(Value::Ctor { name: ".True".into(), args: vec![] }),
-                    Value::Symbol(id) if env.symbol_name(*id) == ".False" => Ok(Value::Ctor { name: ".False".into(), args: vec![] }),
+                    Value::Symbol(id) if env.symbol_name(*id) == ".True" => {
+                        Ok(Value::Ctor { name: ".True".into(), args: vec![] })
+                    }
+                    Value::Symbol(id) if env.symbol_name(*id) == ".False" => {
+                        Ok(Value::Ctor { name: ".False".into(), args: vec![] })
+                    }
                     _ => Err(EvalError::TypeError),
                 },
             },
@@ -394,7 +398,11 @@ impl Env {
                 args: vec![],
                 f: |env, args| {
                     let res = v_equal(env, &args[0], &args[1]);
-                    Ok(if res { Value::Ctor { name: ".True".into(), args: vec![] } } else { Value::Ctor { name: ".False".into(), args: vec![] } })
+                    Ok(if res {
+                        Value::Ctor { name: ".True".into(), args: vec![] }
+                    } else {
+                        Value::Ctor { name: ".False".into(), args: vec![] }
+                    })
                 },
             },
         );
@@ -641,7 +649,9 @@ impl Env {
 
         // char classification namespace
         let mut char_ns: BTreeMap<String, Value> = BTreeMap::new();
-    fn bool_val(b: bool) -> Value { bool_ctor(b) }
+        fn bool_val(b: bool) -> Value {
+            bool_ctor(b)
+        }
         char_ns.insert(
             "is_alpha".into(),
             Value::Native {
@@ -1157,7 +1167,7 @@ fn to_str_like(env: &Env, v: &Value) -> String {
     match &vv {
         Value::Unit => "()".into(),
         Value::Int(n) => n.to_string(),
-    Value::Float(f) => f.to_string(),
+        Value::Float(f) => f.to_string(),
         Value::Str(s) => s.to_string(),
         Value::Char(c) => char_literal_string(*c),
         Value::Symbol(id) => env.symbol_name(*id),
@@ -1206,7 +1216,13 @@ fn char_literal_string(c: i32) -> String {
     format!("'{}'", tmp.escape_default())
 }
 
-fn bool_ctor(b: bool) -> Value { if b { Value::Ctor { name: ".True".into(), args: vec![] } } else { Value::Ctor { name: ".False".into(), args: vec![] } } }
+fn bool_ctor(b: bool) -> Value {
+    if b {
+        Value::Ctor { name: ".True".into(), args: vec![] }
+    } else {
+        Value::Ctor { name: ".False".into(), args: vec![] }
+    }
+}
 
 fn as_bool(env: &Env, v: &Value) -> Result<bool, EvalError> {
     let v = force_value(env, v)?;
@@ -1215,7 +1231,13 @@ fn as_bool(env: &Env, v: &Value) -> Result<bool, EvalError> {
         Value::Ctor { name, args } if args.is_empty() && name == ".False" => Ok(false),
         Value::Symbol(id) => {
             let s = env.symbol_name(*id);
-            if s == ".True" { Ok(true) } else if s == ".False" { Ok(false) } else { Err(EvalError::TypeError) }
+            if s == ".True" {
+                Ok(true)
+            } else if s == ".False" {
+                Ok(false)
+            } else {
+                Err(EvalError::TypeError)
+            }
         }
         _ => Err(EvalError::TypeError),
     }
@@ -1246,7 +1268,10 @@ fn eff_print(env: &Env, args: &[Value]) -> Result<Value, EvalError> {
                 print!("{}", n);
                 Ok(Value::Unit)
             }
-            Value::Float(f) => { print!("{}", f); Ok(Value::Unit) }
+            Value::Float(f) => {
+                print!("{}", f);
+                Ok(Value::Unit)
+            }
             Value::Char(c) => {
                 print!("{}", char_literal_string(c));
                 Ok(Value::Unit)
@@ -1326,7 +1351,10 @@ fn eff_println(env: &Env, args: &[Value]) -> Result<Value, EvalError> {
                 println!("{}", n);
                 Ok(Value::Unit)
             }
-            Value::Float(f) => { println!("{}", f); Ok(Value::Unit) }
+            Value::Float(f) => {
+                println!("{}", f);
+                Ok(Value::Unit)
+            }
             Value::Char(c) => {
                 println!("{}", char_literal_string(c));
                 Ok(Value::Unit)
@@ -1394,7 +1422,7 @@ fn v_equal(_env: &Env, a: &Value, b: &Value) -> bool {
     match (a, b) {
         (Value::Unit, Value::Unit) => true,
         (Value::Int(x), Value::Int(y)) => x == y,
-    (Value::Float(x), Value::Float(y)) => x == y,
+        (Value::Float(x), Value::Float(y)) => x == y,
         (Value::Str(x), Value::Str(y)) => x == y,
         (Value::Char(x), Value::Char(y)) => x == y,
         (Value::Symbol(x), Value::Symbol(y)) => x == y,
@@ -2182,7 +2210,7 @@ mod tests {
         let env = Env::with_builtins();
         let v = eval(&env, &whole).unwrap();
         match v {
-            Value::Ctor { name, .. } if name == ".True" => {},
+            Value::Ctor { name, .. } if name == ".True" => {}
             _ => panic!("expected Bool true"),
         }
 
@@ -2203,7 +2231,7 @@ mod tests {
         let env2 = Env::with_builtins();
         let v = eval(&env2, &whole).unwrap();
         match v {
-            Value::Ctor { name, .. } if name == ".False" => {},
+            Value::Ctor { name, .. } if name == ".False" => {}
             _ => panic!("expected Bool false"),
         }
     }

--- a/crates/lzscr-runtime/src/lib.rs
+++ b/crates/lzscr-runtime/src/lib.rs
@@ -201,12 +201,12 @@ impl Env {
     pub fn with_builtins() -> Self {
         let mut e = Env::new();
 
-    // Bool via constructors .True / .False (no legacy ~true/~false refs)
-    e.declare_ctor_arity(".True", 0);
-    e.declare_ctor_arity(".False", 0);
-    // Pre-intern commonly used symbols
-    let _ = e.intern_symbol(".True");
-    let _ = e.intern_symbol(".False");
+        // Bool via constructors .True / .False (no legacy ~true/~false refs)
+        e.declare_ctor_arity(".True", 0);
+        e.declare_ctor_arity(".False", 0);
+        // Pre-intern commonly used symbols
+        let _ = e.intern_symbol(".True");
+        let _ = e.intern_symbol(".False");
         let _ = e.intern_symbol(".print");
         let _ = e.intern_symbol(".println");
         let _ = e.intern_symbol(".,");
@@ -387,7 +387,7 @@ impl Env {
             },
         );
 
-    // eq : Int|Float|Bool|Str|Unit|Symbol -> same -> Bool
+        // eq : Int|Float|Bool|Str|Unit|Symbol -> same -> Bool
         e.vars.insert(
             "eq".into(),
             Value::Native {
@@ -400,73 +400,57 @@ impl Env {
             },
         );
 
-    // lt : Int|Float -> Int|Float -> Bool
+        // lt : Int|Float -> Int|Float -> Bool
         e.vars.insert(
             "lt".into(),
             Value::Native {
                 arity: 2,
                 args: vec![],
                 f: |_env, args| match (&args[0], &args[1]) {
-                    (Value::Int(a), Value::Int(b)) => {
-                        Ok(Value::Bool(a < b))
-                    }
-                    (Value::Float(a), Value::Float(b)) => {
-                        Ok(Value::Bool(a < b))
-                    }
+                    (Value::Int(a), Value::Int(b)) => Ok(Value::Bool(a < b)),
+                    (Value::Float(a), Value::Float(b)) => Ok(Value::Bool(a < b)),
                     _ => Err(EvalError::TypeError),
                 },
             },
         );
 
-    // le : Int|Float -> Int|Float -> Bool
+        // le : Int|Float -> Int|Float -> Bool
         e.vars.insert(
             "le".into(),
             Value::Native {
                 arity: 2,
                 args: vec![],
                 f: |_env, args| match (&args[0], &args[1]) {
-                    (Value::Int(a), Value::Int(b)) => {
-                        Ok(Value::Bool(a <= b))
-                    }
-                    (Value::Float(a), Value::Float(b)) => {
-                        Ok(Value::Bool(a <= b))
-                    }
+                    (Value::Int(a), Value::Int(b)) => Ok(Value::Bool(a <= b)),
+                    (Value::Float(a), Value::Float(b)) => Ok(Value::Bool(a <= b)),
                     _ => Err(EvalError::TypeError),
                 },
             },
         );
 
-    // gt : Int|Float -> Int|Float -> Bool
+        // gt : Int|Float -> Int|Float -> Bool
         e.vars.insert(
             "gt".into(),
             Value::Native {
                 arity: 2,
                 args: vec![],
                 f: |_env, args| match (&args[0], &args[1]) {
-                    (Value::Int(a), Value::Int(b)) => {
-                        Ok(Value::Bool(a > b))
-                    }
-                    (Value::Float(a), Value::Float(b)) => {
-                        Ok(Value::Bool(a > b))
-                    }
+                    (Value::Int(a), Value::Int(b)) => Ok(Value::Bool(a > b)),
+                    (Value::Float(a), Value::Float(b)) => Ok(Value::Bool(a > b)),
                     _ => Err(EvalError::TypeError),
                 },
             },
         );
 
-    // ge : Int|Float -> Int|Float -> Bool
+        // ge : Int|Float -> Int|Float -> Bool
         e.vars.insert(
             "ge".into(),
             Value::Native {
                 arity: 2,
                 args: vec![],
                 f: |_env, args| match (&args[0], &args[1]) {
-                    (Value::Int(a), Value::Int(b)) => {
-                        Ok(Value::Bool(a >= b))
-                    }
-                    (Value::Float(a), Value::Float(b)) => {
-                        Ok(Value::Bool(a >= b))
-                    }
+                    (Value::Int(a), Value::Int(b)) => Ok(Value::Bool(a >= b)),
+                    (Value::Float(a), Value::Float(b)) => Ok(Value::Bool(a >= b)),
                     _ => Err(EvalError::TypeError),
                 },
             },
@@ -492,9 +476,7 @@ impl Env {
                 arity: 2,
                 args: vec![],
                 f: |_env, args| match (&args[0], &args[1]) {
-                    (Value::Float(a), Value::Float(b)) => {
-                        Ok(Value::Bool(a < b))
-                    }
+                    (Value::Float(a), Value::Float(b)) => Ok(Value::Bool(a < b)),
                     _ => Err(EvalError::TypeError),
                 },
             },
@@ -505,9 +487,7 @@ impl Env {
                 arity: 2,
                 args: vec![],
                 f: |_env, args| match (&args[0], &args[1]) {
-                    (Value::Float(a), Value::Float(b)) => {
-                        Ok(Value::Bool(a <= b))
-                    }
+                    (Value::Float(a), Value::Float(b)) => Ok(Value::Bool(a <= b)),
                     _ => Err(EvalError::TypeError),
                 },
             },
@@ -518,9 +498,7 @@ impl Env {
                 arity: 2,
                 args: vec![],
                 f: |_env, args| match (&args[0], &args[1]) {
-                    (Value::Float(a), Value::Float(b)) => {
-                        Ok(Value::Bool(a > b))
-                    }
+                    (Value::Float(a), Value::Float(b)) => Ok(Value::Bool(a > b)),
                     _ => Err(EvalError::TypeError),
                 },
             },
@@ -531,9 +509,7 @@ impl Env {
                 arity: 2,
                 args: vec![],
                 f: |_env, args| match (&args[0], &args[1]) {
-                    (Value::Float(a), Value::Float(b)) => {
-                        Ok(Value::Bool(a >= b))
-                    }
+                    (Value::Float(a), Value::Float(b)) => Ok(Value::Bool(a >= b)),
                     _ => Err(EvalError::TypeError),
                 },
             },
@@ -664,9 +640,11 @@ impl Env {
             }
         }
 
-    // char classification namespace
-    let mut char_ns: BTreeMap<String, Value> = BTreeMap::new();
-    fn bool_val(b: bool) -> Value { Value::Bool(b) }
+        // char classification namespace
+        let mut char_ns: BTreeMap<String, Value> = BTreeMap::new();
+        fn bool_val(b: bool) -> Value {
+            Value::Bool(b)
+        }
         char_ns.insert(
             "is_alpha".into(),
             Value::Native {
@@ -779,17 +757,17 @@ impl Env {
                 },
             },
         );
-    // eof : Scan -> Bool
+        // eof : Scan -> Bool
         scan_ns.insert(
             "eof".into(),
             Value::Native {
                 arity: 1,
                 args: vec![],
-        f: |_env, args| match &args[0] {
+                f: |_env, args| match &args[0] {
                     v if get_scan(v).is_some() => {
                         let (s, i) = get_scan(v).unwrap();
                         let at_end = i >= s.char_count();
-            Ok(Value::Bool(at_end))
+                        Ok(Value::Bool(at_end))
                     }
                     _ => Err(EvalError::TypeError),
                 },
@@ -1104,7 +1082,7 @@ impl Env {
         );
         e.declare_ctor_arity("KV", 2);
 
-    // logical ops: and/or/not. Accept Bool (or legacy Symbol True/False) and return Bool.
+        // logical ops: and/or/not. Accept Bool (or legacy Symbol True/False) and return Bool.
         e.vars.insert(
             "and".into(),
             Value::Native {
@@ -1137,7 +1115,7 @@ impl Env {
         );
 
         // if : cond then else
-    // cond: Bool
+        // cond: Bool
         // then/else: either a raw value, a Closure, or a Native with arity=0. Call closures with Unit; return others as-is.
         e.vars.insert(
             "if".into(),

--- a/crates/lzscr-runtime/src/lib.rs
+++ b/crates/lzscr-runtime/src/lib.rs
@@ -1796,6 +1796,15 @@ pub fn eval(env: &Env, e: &Expr) -> Result<Value, EvalError> {
         ExprKind::Str(s) => Ok(Value::Str(env.intern_string(s))),
         ExprKind::Float(f) => Ok(Value::Float(*f)),
         ExprKind::Char(c) => Ok(Value::Char(*c)),
+        ExprKind::Record(fields) => {
+            // Eagerly evaluate field expressions (could later be lazy if desired)
+            let mut map = std::collections::BTreeMap::new();
+            for (k, v) in fields {
+                let val = eval(env, v)?;
+                map.insert(k.clone(), val);
+            }
+            Ok(Value::Record(map))
+        }
         ExprKind::LetGroup { bindings, body, .. } => {
             // Support recursion for non-functions via lazy bindings
             // Use a shared environment so RHS thunks see recursive names.

--- a/crates/lzscr-runtime/src/lib.rs
+++ b/crates/lzscr-runtime/src/lib.rs
@@ -218,8 +218,8 @@ impl Env {
                 arity: 1,
                 args: vec![],
                 f: |env, args| match &args[0] {
-                    Value::Symbol(id) if env.symbol_name(*id) == ".true" => Ok(Value::Bool(true)),
-                    Value::Symbol(id) if env.symbol_name(*id) == ".false" => Ok(Value::Bool(false)),
+                    Value::Symbol(id) if env.symbol_name(*id) == ".True" => Ok(Value::Bool(true)),
+                    Value::Symbol(id) if env.symbol_name(*id) == ".False" => Ok(Value::Bool(false)),
                     _ => Err(EvalError::TypeError),
                 },
             },
@@ -395,7 +395,7 @@ impl Env {
                 args: vec![],
                 f: |env, args| {
                     let res = v_equal(env, &args[0], &args[1]);
-                    Ok(if res { sym_true(env) } else { sym_false(env) })
+                    Ok(Value::Bool(res))
                 },
             },
         );
@@ -406,12 +406,12 @@ impl Env {
             Value::Native {
                 arity: 2,
                 args: vec![],
-                f: |env, args| match (&args[0], &args[1]) {
+                f: |_env, args| match (&args[0], &args[1]) {
                     (Value::Int(a), Value::Int(b)) => {
-                        Ok(if a < b { sym_true(env) } else { sym_false(env) })
+                        Ok(Value::Bool(a < b))
                     }
                     (Value::Float(a), Value::Float(b)) => {
-                        Ok(if a < b { sym_true(env) } else { sym_false(env) })
+                        Ok(Value::Bool(a < b))
                     }
                     _ => Err(EvalError::TypeError),
                 },
@@ -424,12 +424,12 @@ impl Env {
             Value::Native {
                 arity: 2,
                 args: vec![],
-                f: |env, args| match (&args[0], &args[1]) {
+                f: |_env, args| match (&args[0], &args[1]) {
                     (Value::Int(a), Value::Int(b)) => {
-                        Ok(if a <= b { sym_true(env) } else { sym_false(env) })
+                        Ok(Value::Bool(a <= b))
                     }
                     (Value::Float(a), Value::Float(b)) => {
-                        Ok(if a <= b { sym_true(env) } else { sym_false(env) })
+                        Ok(Value::Bool(a <= b))
                     }
                     _ => Err(EvalError::TypeError),
                 },
@@ -442,12 +442,12 @@ impl Env {
             Value::Native {
                 arity: 2,
                 args: vec![],
-                f: |env, args| match (&args[0], &args[1]) {
+                f: |_env, args| match (&args[0], &args[1]) {
                     (Value::Int(a), Value::Int(b)) => {
-                        Ok(if a > b { sym_true(env) } else { sym_false(env) })
+                        Ok(Value::Bool(a > b))
                     }
                     (Value::Float(a), Value::Float(b)) => {
-                        Ok(if a > b { sym_true(env) } else { sym_false(env) })
+                        Ok(Value::Bool(a > b))
                     }
                     _ => Err(EvalError::TypeError),
                 },
@@ -460,12 +460,12 @@ impl Env {
             Value::Native {
                 arity: 2,
                 args: vec![],
-                f: |env, args| match (&args[0], &args[1]) {
+                f: |_env, args| match (&args[0], &args[1]) {
                     (Value::Int(a), Value::Int(b)) => {
-                        Ok(if a >= b { sym_true(env) } else { sym_false(env) })
+                        Ok(Value::Bool(a >= b))
                     }
                     (Value::Float(a), Value::Float(b)) => {
-                        Ok(if a >= b { sym_true(env) } else { sym_false(env) })
+                        Ok(Value::Bool(a >= b))
                     }
                     _ => Err(EvalError::TypeError),
                 },
@@ -480,7 +480,7 @@ impl Env {
                 args: vec![],
                 f: |env, args| {
                     let res = !v_equal(env, &args[0], &args[1]);
-                    Ok(if res { sym_true(env) } else { sym_false(env) })
+                    Ok(Value::Bool(res))
                 },
             },
         );
@@ -491,9 +491,9 @@ impl Env {
             Value::Native {
                 arity: 2,
                 args: vec![],
-                f: |env, args| match (&args[0], &args[1]) {
+                f: |_env, args| match (&args[0], &args[1]) {
                     (Value::Float(a), Value::Float(b)) => {
-                        Ok(if a < b { sym_true(env) } else { sym_false(env) })
+                        Ok(Value::Bool(a < b))
                     }
                     _ => Err(EvalError::TypeError),
                 },
@@ -504,9 +504,9 @@ impl Env {
             Value::Native {
                 arity: 2,
                 args: vec![],
-                f: |env, args| match (&args[0], &args[1]) {
+                f: |_env, args| match (&args[0], &args[1]) {
                     (Value::Float(a), Value::Float(b)) => {
-                        Ok(if a <= b { sym_true(env) } else { sym_false(env) })
+                        Ok(Value::Bool(a <= b))
                     }
                     _ => Err(EvalError::TypeError),
                 },
@@ -517,9 +517,9 @@ impl Env {
             Value::Native {
                 arity: 2,
                 args: vec![],
-                f: |env, args| match (&args[0], &args[1]) {
+                f: |_env, args| match (&args[0], &args[1]) {
                     (Value::Float(a), Value::Float(b)) => {
-                        Ok(if a > b { sym_true(env) } else { sym_false(env) })
+                        Ok(Value::Bool(a > b))
                     }
                     _ => Err(EvalError::TypeError),
                 },
@@ -530,9 +530,9 @@ impl Env {
             Value::Native {
                 arity: 2,
                 args: vec![],
-                f: |env, args| match (&args[0], &args[1]) {
+                f: |_env, args| match (&args[0], &args[1]) {
                     (Value::Float(a), Value::Float(b)) => {
-                        Ok(if a >= b { sym_true(env) } else { sym_false(env) })
+                        Ok(Value::Bool(a >= b))
                     }
                     _ => Err(EvalError::TypeError),
                 },
@@ -664,25 +664,18 @@ impl Env {
             }
         }
 
-        // char classification namespace
-        let mut char_ns: BTreeMap<String, Value> = BTreeMap::new();
-        // helpers to convert bool -> Symbol("True"|"False")
-        fn to_sym_bool(env: &Env, b: bool) -> Value {
-            if b {
-                sym_true(env)
-            } else {
-                sym_false(env)
-            }
-        }
+    // char classification namespace
+    let mut char_ns: BTreeMap<String, Value> = BTreeMap::new();
+    fn bool_val(b: bool) -> Value { Value::Bool(b) }
         char_ns.insert(
             "is_alpha".into(),
             Value::Native {
                 arity: 1,
                 args: vec![],
-                f: |env, args| match &args[0] {
+                f: |_env, args| match &args[0] {
                     Value::Char(c) => {
                         let ch = char::from_u32(*c as u32).unwrap_or('\u{0}');
-                        Ok(to_sym_bool(env, ch.is_alphabetic()))
+                        Ok(bool_val(ch.is_alphabetic()))
                     }
                     _ => Err(EvalError::TypeError),
                 },
@@ -693,10 +686,10 @@ impl Env {
             Value::Native {
                 arity: 1,
                 args: vec![],
-                f: |env, args| match &args[0] {
+                f: |_env, args| match &args[0] {
                     Value::Char(c) => {
                         let ch = char::from_u32(*c as u32).unwrap_or('\u{0}');
-                        Ok(to_sym_bool(env, ch.is_ascii_digit()))
+                        Ok(bool_val(ch.is_ascii_digit()))
                     }
                     _ => Err(EvalError::TypeError),
                 },
@@ -707,10 +700,10 @@ impl Env {
             Value::Native {
                 arity: 1,
                 args: vec![],
-                f: |env, args| match &args[0] {
+                f: |_env, args| match &args[0] {
                     Value::Char(c) => {
                         let ch = char::from_u32(*c as u32).unwrap_or('\u{0}');
-                        Ok(to_sym_bool(env, ch.is_ascii_alphanumeric()))
+                        Ok(bool_val(ch.is_ascii_alphanumeric()))
                     }
                     _ => Err(EvalError::TypeError),
                 },
@@ -721,10 +714,10 @@ impl Env {
             Value::Native {
                 arity: 1,
                 args: vec![],
-                f: |env, args| match &args[0] {
+                f: |_env, args| match &args[0] {
                     Value::Char(c) => {
                         let ch = char::from_u32(*c as u32).unwrap_or('\u{0}');
-                        Ok(to_sym_bool(env, ch.is_whitespace()))
+                        Ok(bool_val(ch.is_whitespace()))
                     }
                     _ => Err(EvalError::TypeError),
                 },
@@ -735,10 +728,10 @@ impl Env {
             Value::Native {
                 arity: 3,
                 args: vec![],
-                f: |env, args| match (&args[0], &args[1], &args[2]) {
+                f: |_env, args| match (&args[0], &args[1], &args[2]) {
                     (Value::Char(c), Value::Int(lo), Value::Int(hi)) => {
                         let code = *c as i64;
-                        Ok(to_sym_bool(env, code >= *lo && code <= *hi))
+                        Ok(bool_val(code >= *lo && code <= *hi))
                     }
                     _ => Err(EvalError::TypeError),
                 },
@@ -786,17 +779,17 @@ impl Env {
                 },
             },
         );
-        // eof : Scan -> Symbol("True"|"False")
+    // eof : Scan -> Bool
         scan_ns.insert(
             "eof".into(),
             Value::Native {
                 arity: 1,
                 args: vec![],
-                f: |env, args| match &args[0] {
+        f: |_env, args| match &args[0] {
                     v if get_scan(v).is_some() => {
                         let (s, i) = get_scan(v).unwrap();
                         let at_end = i >= s.char_count();
-                        Ok(if at_end { sym_true(env) } else { sym_false(env) })
+            Ok(Value::Bool(at_end))
                     }
                     _ => Err(EvalError::TypeError),
                 },
@@ -1111,15 +1104,15 @@ impl Env {
         );
         e.declare_ctor_arity("KV", 2);
 
-        // logical ops: and/or/not. Accept Bool or Symbol("True"|"False"). Return Symbol("True"|"False").
+    // logical ops: and/or/not. Accept Bool (or legacy Symbol True/False) and return Bool.
         e.vars.insert(
             "and".into(),
             Value::Native {
                 arity: 2,
                 args: vec![],
                 f: |env, args| match (as_bool(env, &args[0])?, as_bool(env, &args[1])?) {
-                    (true, true) => Ok(sym_true(env)),
-                    _ => Ok(sym_false(env)),
+                    (true, true) => Ok(Value::Bool(true)),
+                    _ => Ok(Value::Bool(false)),
                 },
             },
         );
@@ -1129,8 +1122,8 @@ impl Env {
                 arity: 2,
                 args: vec![],
                 f: |env, args| match (as_bool(env, &args[0])?, as_bool(env, &args[1])?) {
-                    (false, false) => Ok(sym_false(env)),
-                    _ => Ok(sym_true(env)),
+                    (false, false) => Ok(Value::Bool(false)),
+                    _ => Ok(Value::Bool(true)),
                 },
             },
         );
@@ -1139,9 +1132,7 @@ impl Env {
             Value::Native {
                 arity: 1,
                 args: vec![],
-                f: |env, args| {
-                    Ok(if as_bool(env, &args[0])? { sym_false(env) } else { sym_true(env) })
-                },
+                f: |env, args| Ok(Value::Bool(!as_bool(env, &args[0])?)),
             },
         );
 
@@ -1241,27 +1232,10 @@ fn char_literal_string(c: i32) -> String {
     format!("'{}'", tmp.escape_default())
 }
 
-fn sym_true(env: &Env) -> Value {
-    Value::Symbol(env.intern_symbol("True"))
-}
-fn sym_false(env: &Env) -> Value {
-    Value::Symbol(env.intern_symbol("False"))
-}
-
 fn as_bool(env: &Env, v: &Value) -> Result<bool, EvalError> {
     let v = force_value(env, v)?;
     match &v {
         Value::Bool(b) => Ok(*b),
-        Value::Symbol(id) => {
-            let s = env.symbol_name(*id);
-            if s == "True" {
-                Ok(true)
-            } else if s == "False" {
-                Ok(false)
-            } else {
-                Err(EvalError::TypeError)
-            }
-        }
         _ => Err(EvalError::TypeError),
     }
 }

--- a/crates/lzscr-runtime/src/lib.rs
+++ b/crates/lzscr-runtime/src/lib.rs
@@ -387,7 +387,7 @@ impl Env {
             },
         );
 
-        // eq : Int|Float|Bool|Str|Unit|Symbol -> same -> Symbol("True"|"False")
+    // eq : Int|Float|Bool|Str|Unit|Symbol -> same -> Bool
         e.vars.insert(
             "eq".into(),
             Value::Native {
@@ -400,7 +400,7 @@ impl Env {
             },
         );
 
-        // lt : Int|Float -> Int|Float -> Symbol("True"|"False")
+    // lt : Int|Float -> Int|Float -> Bool
         e.vars.insert(
             "lt".into(),
             Value::Native {
@@ -418,7 +418,7 @@ impl Env {
             },
         );
 
-        // le : Int|Float -> Int|Float -> Symbol("True"|"False")
+    // le : Int|Float -> Int|Float -> Bool
         e.vars.insert(
             "le".into(),
             Value::Native {
@@ -436,7 +436,7 @@ impl Env {
             },
         );
 
-        // gt : Int|Float -> Int|Float -> Symbol("True"|"False")
+    // gt : Int|Float -> Int|Float -> Bool
         e.vars.insert(
             "gt".into(),
             Value::Native {
@@ -454,7 +454,7 @@ impl Env {
             },
         );
 
-        // ge : Int|Float -> Int|Float -> Symbol("True"|"False")
+    // ge : Int|Float -> Int|Float -> Bool
         e.vars.insert(
             "ge".into(),
             Value::Native {
@@ -1137,7 +1137,7 @@ impl Env {
         );
 
         // if : cond then else
-        // cond: Bool or Symbol("True"|"False")
+    // cond: Bool
         // then/else: either a raw value, a Closure, or a Native with arity=0. Call closures with Unit; return others as-is.
         e.vars.insert(
             "if".into(),
@@ -2221,8 +2221,8 @@ mod tests {
         let env = Env::with_builtins();
         let v = eval(&env, &whole).unwrap();
         match v {
-            Value::Symbol(id) => assert_eq!(env.symbol_name(id), "True"),
-            _ => panic!("expected Symbol True"),
+            Value::Bool(b) => assert!(b, "expected Bool true"),
+            _ => panic!("expected Bool true"),
         }
 
         // Different tag
@@ -2242,8 +2242,8 @@ mod tests {
         let env2 = Env::with_builtins();
         let v = eval(&env2, &whole).unwrap();
         match v {
-            Value::Symbol(id) => assert_eq!(env2.symbol_name(id), "False"),
-            _ => panic!("expected Symbol False"),
+            Value::Bool(b) => assert!(!b, "expected Bool false"),
+            _ => panic!("expected Bool false"),
         }
     }
 

--- a/crates/lzscr-types/src/lib.rs
+++ b/crates/lzscr-types/src/lib.rs
@@ -1105,8 +1105,12 @@ fn infer_expr(
             Ok((inst, Subst::new()))
         }
         ExprKind::Symbol(name) => {
-            // Treat bare symbol as ctor value of arity 0 at type level
-            Ok((Type::Ctor { tag: name.clone(), payload: vec![] }, Subst::new()))
+            if name == ".True" || name == ".False" {
+                Ok((Type::Bool, Subst::new()))
+            } else {
+                // Treat other bare symbol as 0-arity ctor
+                Ok((Type::Ctor { tag: name.clone(), payload: vec![] }, Subst::new()))
+            }
         }
         ExprKind::Lambda { param, body } => {
             // Handle pattern-level type binders: push frames while inferring param and body
@@ -2111,8 +2115,6 @@ pub mod api {
         );
         env.insert("not".into(), Scheme { vars: vec![], ty: Type::fun(Type::Bool, Type::Bool) });
         // boolean values
-        env.insert("true".into(), Scheme { vars: vec![], ty: Type::Bool });
-        env.insert("false".into(), Scheme { vars: vec![], ty: Type::Bool });
         // seq : forall a b. a -> b -> b
         let a2 = TvId(1002);
         let b2 = TvId(1003);

--- a/crates/lzscr-types/src/lib.rs
+++ b/crates/lzscr-types/src/lib.rs
@@ -154,11 +154,11 @@ impl TypesApply for Type {
         match self {
             Type::Var(v) => s.0.get(v).cloned().unwrap_or(Type::Var(*v)),
             Type::Fun(a, b) => Type::fun(a.apply(s), b.apply(s)),
-            Type::List(t) => Type::List(Box::new(t.apply(s))),
-            Type::Tuple(ts) => Type::Tuple(ts.iter().map(|t| t.apply(s)).collect()),
+            Type::List(x) => Type::List(Box::new(x.apply(s))),
+            Type::Tuple(xs) => Type::Tuple(xs.iter().map(|t| t.apply(s)).collect()),
             Type::Record(fs) => {
                 let mut m = BTreeMap::new();
-                for (k, v) in fs.iter() {
+                for (k, v) in fs {
                     m.insert(k.clone(), v.apply(s));
                 }
                 Type::Record(m)
@@ -477,8 +477,8 @@ fn unify(a: &Type, b: &Type) -> Result<Subst, TypeError> {
                 Ok(s)
             } else {
                 Err(TypeError::Mismatch {
-                    expected: Type::SumCtor(variants.clone()),
-                    actual: Type::Ctor { tag: tag.clone(), payload: payload.clone() },
+                    expected: a.clone(),
+                    actual: b.clone(),
                     span_offset: 0,
                     span_len: 0,
                 })

--- a/crates/lzscr-types/src/lib.rs
+++ b/crates/lzscr-types/src/lib.rs
@@ -180,9 +180,7 @@ impl TypesApply for Type {
                     .map(|(n, ps)| (n.clone(), ps.iter().map(|t| t.apply(s)).collect()))
                     .collect(),
             ),
-            t @ (Type::Unit | Type::Int | Type::Float | Type::Str | Type::Char) => {
-                t.clone()
-            }
+            t @ (Type::Unit | Type::Int | Type::Float | Type::Str | Type::Char) => t.clone(),
         }
     }
     fn ftv(&self) -> HashSet<TvId> {
@@ -380,11 +378,11 @@ fn unify(a: &Type, b: &Type) -> Result<Subst, TypeError> {
     match (a, b) {
         (Type::Var(x), t) => bind(*x, t.clone()),
         (t, Type::Var(x)) => bind(*x, t.clone()),
-    (Type::Unit, Type::Unit)
-    | (Type::Int, Type::Int)
-    | (Type::Float, Type::Float)
-    | (Type::Str, Type::Str)
-    | (Type::Char, Type::Char) => Ok(Subst::new()),
+        (Type::Unit, Type::Unit)
+        | (Type::Int, Type::Int)
+        | (Type::Float, Type::Float)
+        | (Type::Str, Type::Str)
+        | (Type::Char, Type::Char) => Ok(Subst::new()),
         (Type::Fun(a1, b1), Type::Fun(a2, b2)) => {
             let s1 = unify(a1, a2)?;
             let s2 = unify(&b1.apply(&s1), &b2.apply(&s1))?;
@@ -554,7 +552,7 @@ fn conv_typeexpr_with_subst(
         TypeExpr::Unit => Type::Unit,
         TypeExpr::Int => Type::Int,
         TypeExpr::Float => Type::Float,
-    TypeExpr::Bool => bool_sum_type(),
+        TypeExpr::Bool => bool_sum_type(),
         TypeExpr::Str => Type::Str,
         TypeExpr::Char => Type::Char,
         TypeExpr::List(t) => Type::List(Box::new(conv_typeexpr_with_subst(ctx, t, subst)?)),
@@ -983,7 +981,7 @@ fn conv_typeexpr_fresh(tv: &mut TvGen, te: &TypeExpr) -> Type {
         TypeExpr::Unit => Type::Unit,
         TypeExpr::Int => Type::Int,
         TypeExpr::Float => Type::Float,
-    TypeExpr::Bool => bool_sum_type(),
+        TypeExpr::Bool => bool_sum_type(),
         TypeExpr::Str => Type::Str,
         TypeExpr::Char => Type::Char,
         TypeExpr::List(t) => Type::List(Box::new(conv_typeexpr_fresh(tv, t))),
@@ -1798,10 +1796,10 @@ fn pp_type(t: &Type) -> String {
         format!("%t{id}")
     }
     match t {
-    Type::Unit => "Unit".into(),
-    Type::Int => "Int".into(),
-    Type::Float => "Float".into(),
-    Type::Str => "Str".into(),
+        Type::Unit => "Unit".into(),
+        Type::Int => "Int".into(),
+        Type::Float => "Float".into(),
+        Type::Str => "Str".into(),
         Type::Char => "Char".into(),
         Type::Var(TvId(i)) => rename_var(*i as i64),
         Type::List(a) => format!("[{}]", pp_type(a)),
@@ -2190,13 +2188,22 @@ pub mod api {
         let bool_t = bool_sum_type();
         env.insert(
             "and".into(),
-            Scheme { vars: vec![], ty: Type::fun(bool_t.clone(), Type::fun(bool_t.clone(), bool_t.clone())) },
+            Scheme {
+                vars: vec![],
+                ty: Type::fun(bool_t.clone(), Type::fun(bool_t.clone(), bool_t.clone())),
+            },
         );
         env.insert(
             "or".into(),
-            Scheme { vars: vec![], ty: Type::fun(bool_t.clone(), Type::fun(bool_t.clone(), bool_t.clone())) },
+            Scheme {
+                vars: vec![],
+                ty: Type::fun(bool_t.clone(), Type::fun(bool_t.clone(), bool_t.clone())),
+            },
         );
-        env.insert("not".into(), Scheme { vars: vec![], ty: Type::fun(bool_t.clone(), bool_t.clone()) });
+        env.insert(
+            "not".into(),
+            Scheme { vars: vec![], ty: Type::fun(bool_t.clone(), bool_t.clone()) },
+        );
         // boolean values
         // seq : forall a b. a -> b -> b
         let a2 = TvId(1002);

--- a/deny.toml
+++ b/deny.toml
@@ -20,12 +20,8 @@ version = 2
 allow = [
   "Apache-2.0",
   "MIT",
-  "BSD-3-Clause",
   "BSD-2-Clause",
-  "Unicode-DFS-2016",
   "Unicode-3.0",   # required by unicode-ident via chumsky
-  "ISC",
-  "Zlib",
 ]
 confidence-threshold = 0.8   # still supported
 

--- a/docs/lzscr.md
+++ b/docs/lzscr.md
@@ -192,7 +192,7 @@ Representative builtin kinds:
 - `seq : a -> b -> b` (Pure; second arg may be IO under context check)
 - `chain/bind` are context-driven (checked by the runtime and, future, by kinds)
 
-Note: We represent booleans as `.true`/`.false` tags via a `Bool` constructor in the surface language; `true()`/`false()` sugar expands to `~true`/`~false` for convenience.
+Note: Booleans are represented by constructors `.True` / `.False` (the earlier `~true` / `~false` aliases and `true()`/`false()` sugar have been removed).
 
 ### 10) Constructors and patterns (.Member-only)
 

--- a/docs/spec/language.md
+++ b/docs/spec/language.md
@@ -143,7 +143,7 @@ Note: Always use `~` on pattern variables (write `~x`, not `x`).
 - Pattern binding:
   - On success, binds into pre-allocated slots; on failure, produces a caret-style error that propagates.
 
-- Representative builtins (Bool-like results are represented as `Symbol("True"|"False")`):
+- Representative builtins (Bool results are `Bool` values `.True` / `.False`):
   - `to_str : a -> Str` (rendering)
   - `add/sub/mul/div : Int -> Int -> Int` (divide by zero is an error)
   - `fadd/fsub/fmul/fdiv : Float -> Float -> Float`
@@ -178,7 +178,7 @@ Type hints below are informal (to be aligned with the HM type inference). Bool n
   - `to_str : a -> Str`
   - `add, sub, mul, div : Int -> Int -> Int`
   - `fadd, fsub, fmul, fdiv : Float -> Float -> Float`
-  - `eq, ne, lt, le, gt, ge : t -> t -> Bool-like` (returns `Symbol("True"|"False")`)
+  - `eq, ne, lt, le, gt, ge : t -> t -> Bool`
   - `and, or : Bool-like -> Bool-like -> Bool-like`, `not : Bool-like -> Bool-like`
   - `if : Bool-like -> a -> a -> a`
   - `seq : a -> b -> b`, `chain : m -> (Unit -> k) -> k`, `bind : m -> (x -> k) -> k`
@@ -351,8 +351,8 @@ Example:
 6.9 Main builtin types
 
 - `add/sub/mul/div : Int -> Int -> Int`
-- `eq/ne : ∀a. a -> a -> Bool-like` (Symbol("True"|"False"))
-- `lt/le/gt/ge : Int|Float -> Int|Float -> Bool-like` (Symbol("True"|"False"))
+- `eq/ne : ∀a. a -> a -> Bool`
+- `lt/le/gt/ge : Int|Float -> Int|Float -> Bool`
 - `flt/fle/fgt/fge : Float -> Float -> Bool-like`
 - `cons : ∀a. a -> List a -> List a`
 - `to_str : ∀a. a -> Str`

--- a/docs/spec/language.md
+++ b/docs/spec/language.md
@@ -220,7 +220,7 @@ Type hints below are informal (to be aligned with the HM type inference). Bool n
 
 Notes:
 - Zero-arity constructors must be written as `.Ctor()` (bare `Ctor` is parsed as a variable name; Member-only policy).
-- Provide sugar where `true()` / `false()` expand to `~true` / `~false`.
+// Booleans use `.True` / `.False` constructors directly (legacy sugar removed).
 
 ---
 

--- a/docs/spec/semantics.md
+++ b/docs/spec/semantics.md
@@ -18,8 +18,8 @@ Disclaimer: This document describes the current PoC behavior. Items labeled as p
 - Builtins (examples):
   - `to_str : a -> Str`
   - `add, sub : Int -> Int -> Int`
-  - `eq : a -> a -> Symbol("True"|"False")` (supports Int/Float/Bool/Str/Unit/Symbol)
-  - `lt : Int|Float -> Int|Float -> Symbol("True"|"False")`
+  - `eq : a -> a -> Bool` (supports Int/Float/Bool/Str/Unit/Symbol)
+  - `lt : Int|Float -> Int|Float -> Bool`
   - `seq : a -> b -> b` (implemented via ref + special form)
   - `effects .println : Str -> Unit` (only in effect-context)
 Notes:

--- a/docs/spec/semantics.md
+++ b/docs/spec/semantics.md
@@ -23,7 +23,7 @@ Disclaimer: This document describes the current PoC behavior. Items labeled as p
   - `seq : a -> b -> b` (implemented via ref + special form)
   - `effects .println : Str -> Unit` (only in effect-context)
 Notes:
-- Bool currently injects `~true`/`~false` into the environment (literals planned)
+- Bool represented by constructors `.True` / `.False` (no implicit variable aliases)
 - Float supports literals (e.g., 1.0, .5, 10.)
 - Char is currently treated as Int (intended 0..=0x10FFFF); dedicated literal not implemented
 - List/Tuple/Record are immutable values with runtime display and to_str support

--- a/docs/spec/syntax.md
+++ b/docs/spec/syntax.md
@@ -23,7 +23,7 @@ Examples:
 - Int: `42`
 - Float: `1.0`, `.5`, `3.`
 - Str: `"hi"` (supports escapes)
-- Ref: `~name` (e.g., `~add`, `~true`)
+- Ref: `~name` (e.g., `~add`)
 - Symbol value: `.name` (e.g., `.println`, `.Foo`) — constructors are .Member-only
 - Lambda: `\x -> expr`
 - Block: `{ expr }`
@@ -42,7 +42,7 @@ Examples:
     - Final `E` becomes `(~bind E (\x -> x))` (return value)
     - `expr; ACC` becomes `(~chain expr ACC)`
     - `pat <- expr; ACC` becomes `(~bind expr (\pat -> ACC))`
-- Booleans: `true()` → `~true`, `false()` → `~false`
+- Booleans: `.True`, `.False` constructors (no `~true` / `~false` aliases)
 - Constructor value: `.Foo 1 2` → `Ctor(".Foo", [1,2])`
 
 ### Infix operators (left-assoc; Pratt precedence)

--- a/docs/spec/syntax.md
+++ b/docs/spec/syntax.md
@@ -70,7 +70,7 @@ Desugaring (to function application):
   - `a .< b` → `(~flt a) b`, `a .<= b` → `(~fle a) b`, `a .> b` → `(~fgt a) b`, `a .>= b` → `(~fge a) b`
   - `a == b` → `(~eq a) b`, `a != b` → `(~ne a) b`
 
-Return value is currently `Symbol("True"|"False")`.
+Return value is a Bool (`.True` | `.False`).
 
 ### Examples
 

--- a/docs/spec/tokenizer.md
+++ b/docs/spec/tokenizer.md
@@ -23,7 +23,7 @@ Goal: prepare a standard foundation for string scanning and character classifica
   - `take_while : (Char -> Bool) -> Scan -> (Str, Scan)`
   - `take_while1 : (Char -> Bool) -> Scan -> Option((Str, Scan))`
 
-Returned `Bool` internally uses `Symbol("True"|"False")`, compatible with `Builtins.and/or/not`.
+Returned `Bool` values are the native `.True` / `.False` constructors (no Symbol wrapper).
 
 ## stdlib: `stdlib/lex.lzscr`
 

--- a/stdlib/list.lzscr
+++ b/stdlib/list.lzscr
@@ -39,7 +39,7 @@
 );
 
 # zip : [a] -> [b] -> [(a,b)]
-~zip ~xs ~ys = (~zip_with (\~a ~b -> (. , ~a ~b)) ~xs ~ys);
+~zip ~xs ~ys = (~zip_with (\~a ~b -> (~a, ~b)) ~xs ~ys);
 
 # intersperse : a -> [a] -> [a]
 ~intersperse ~sep ~xs = (

--- a/stdlib/list.lzscr
+++ b/stdlib/list.lzscr
@@ -1,10 +1,10 @@
 # stdlib: List extra utilities built atop core prelude (~cons, ~foldl, etc.)
 
 # any : (a -> Bool) -> [a] -> Bool
-~any ~p ~xs = (\[] -> ~false | \( ~h : ~t ) -> (~if (~p ~h) ~true (~any ~p ~t))) ~xs;
+~any ~p ~xs = (\[] -> .False | \( ~h : ~t ) -> (~if (~p ~h) .True (~any ~p ~t))) ~xs;
 
 # all : (a -> Bool) -> [a] -> Bool
-~all ~p ~xs = (\[] -> ~true | \( ~h : ~t ) -> (~if (~p ~h) (~all ~p ~t) ~false)) ~xs;
+~all ~p ~xs = (\[] -> .True | \( ~h : ~t ) -> (~if (~p ~h) (~all ~p ~t) .False)) ~xs;
 
 # sum : [Int] -> Int
 ~sum ~xs = (~foldl (\~acc ~x -> (~acc + ~x)) 0 ~xs);

--- a/stdlib/option.lzscr
+++ b/stdlib/option.lzscr
@@ -2,8 +2,8 @@
 # Provides functional helpers around .Some/.None option-like constructors.
 
 # Predicates
-~is_some = \(.Some _) -> ~true | \.None -> ~false;
-~is_none = \(.Some _) -> ~false | \.None -> ~true;
+~is_some = \(.Some _) -> .True | \.None -> .False;
+~is_none = \(.Some _) -> .False | \.None -> .True;
 
 # map (f : a -> b) : Option a -> Option b
 ~map ~f = \(.Some ~x) -> .Some (~f ~x) | \.None -> .None;
@@ -31,7 +31,7 @@
 ~maybe ~def ~f = \(.Some ~x) -> (~f ~x) | \.None -> ~def;
 
 # contains : (Eq) a => a -> Option a -> Bool
-~contains ~needle = \(.Some ~x) -> (~x == ~needle) | \.None -> ~false;
+~contains ~needle = \(.Some ~x) -> (~x == ~needle) | \.None -> .False;
 
 {
   is_some: ~is_some,

--- a/stdlib/prelude.lzscr
+++ b/stdlib/prelude.lzscr
@@ -11,16 +11,33 @@
 ~id ~x = ~x;
 ~compose ~f ~g ~x = ~f (~g ~x);
 
-# Option (no match/with; lambda-alt chains)
-~is_some = \(.Some _) -> ~true | \.None -> ~false;
-~is_none = \(.Some _) -> ~false | \.None -> ~true;
-~map_option ~f = \(.Some ~x) -> .Some (~f ~x) | \.None -> .None;
-~unwrap_or ~def = \(.Some ~x) -> ~x | \.None -> ~def;
+# ---------------------------------------------------------------------------
+# Modular stdlib (deduplicated): load extended helpers from separate modules.
+# We keep backward-compatible aliases for existing prelude function names.
+# Future: introduce type declarations (e.g. %Option, %Result) here or in a
+# dedicated types file once the syntax is stabilized.
 
-# Result (minimal)
-~map_result ~f = \(.Ok ~x) -> .Ok (~f ~x) | \(.Err ~e) -> .Err ~e;
-~map_err ~f = \(.Ok ~x) -> .Ok ~x | \(.Err ~e) -> .Err (~f ~e);
-~unwrap_or_else ~f = \(.Ok ~x) -> ~x | \(.Err ~e) -> (~f ~e);
+# Load modules (records) via ~require expansion
+~Option = (~require .option);
+~Result = (~require .result);
+~ListExtra = (~require .list);
+
+# Back-compat Option helper aliases (deprecated: prefer (~Option .map) etc.)
+~is_some = (~Option .is_some);          # DEPRECATED (use (~Option .is_some))
+~is_none = (~Option .is_none);          # DEPRECATED
+~map_option = (~Option .map);           # DEPRECATED (name kept to avoid clash with list ~map)
+~unwrap_or = (~Option .unwrap_or);      # DEPRECATED (Option version)
+# Note: Option also has unwrap_or_else; expose ONLY Result variant under the
+# legacy prelude name to avoid silent behavior change. Access Option's version
+# explicitly via (~Option .unwrap_or_else).
+
+# Back-compat Result helper aliases
+~map_result = (~Result .map);           # DEPRECATED (use (~Result .map))
+~map_err = (~Result .map_err);          # DEPRECATED
+~unwrap_or_else = (~Result .unwrap_or_else);  # DEPRECATED
+
+# (Optional future) Re-export selected list extras if desired:
+# e.g. ~list_any = (~ListExtra .any);
 
 # List primitives (lambda-alt on the structural arg)
 ~length ~xs = (\[] -> 0 | \( _ : ~tail ) -> 1 + (~length ~tail)) ~xs;

--- a/stdlib/prelude.lzscr
+++ b/stdlib/prelude.lzscr
@@ -8,6 +8,8 @@
 ~Unicode = ~Builtins .unicode;
 
 # Core helpers
+%Bool = %{ .True | .False };
+
 ~id ~x = ~x;
 ~compose ~f ~g ~x = ~f (~g ~x);
 

--- a/stdlib/prelude.lzscr
+++ b/stdlib/prelude.lzscr
@@ -11,6 +11,7 @@
 ~id ~x = ~x;
 ~compose ~f ~g ~x = ~f (~g ~x);
 
+
 # ---------------------------------------------------------------------------
 # Modular stdlib (deduplicated): load extended helpers from separate modules.
 # We keep backward-compatible aliases for existing prelude function names.
@@ -68,7 +69,7 @@
 ~starts_with ~s ~pre = (
   ~n = (~Str .len ~pre);
   ~m = (~Str .len ~s);
-  ~if (~m >= ~n) (((~Str .slice ~s 0 ~n) == ~pre)) ~false
+  ~if (~m >= ~n) (((~Str .slice ~s 0 ~n) == ~pre)) .False
 );
 
 ~ends_with ~s ~suf = (
@@ -77,7 +78,7 @@
   ~if (~m >= ~n) (
     ~st = ~m - ~n;
     ((~Str .slice ~s ~st ~n) == ~suf)
-  ) ~false
+  ) .False
 );
 
 # String find: index of first occurrence of a character, else .None
@@ -156,12 +157,12 @@
     ~neg = ((~Str .slice ~s 0 1) == "-");
     ~start = (~if (~neg) 1 0);
     ~if (~start >= ~len) .None (
-  ~loop ~i ~acc = (~if (~i >= ~len) ( ~true , ~acc ) (
+  ~loop ~i ~acc = (~if (~i >= ~len) ( .True , ~acc ) (
         ((\(.Some ~c) -> (~if ((~Char .is_digit ~c)) (
             ~d = ((~Unicode .to_int ~c) - (~Unicode .to_int '0'));
             ~loop (~i + 1) ((~acc * 10) + ~d)
-          ) ( ~false , ~acc )))
-         | (\.None -> ( ~false , ~acc )))
+          ) ( .False , ~acc )))
+         | (\.None -> ( .False , ~acc )))
         ((~Str .char_at ~s ~i))
       ));
       ~res = (~loop ~start 0);

--- a/stdlib/readme.md
+++ b/stdlib/readme.md
@@ -6,7 +6,7 @@ core namespaces from the runtime `Builtins` plus foundational list/string/option
 
 ## Files
 
-- `prelude.lzscr`: Core base + Option/Result primitives + list, string, scan helpers.
+- `prelude.lzscr`: Core base + list/string/scan helpers. Now lazily loads `option.lzscr`, `result.lzscr`, and `list.lzscr` via `~require` and exposes backward-compatible deprecated aliases (e.g. `~is_some`, `~map_option`, `~map_result`).
 - `option.lzscr`: Stand-alone Option helper module (functional ops).
 - `result.lzscr`: Stand-alone Result helper module (map/and_then/or_else, etc.).
 - `list.lzscr`: Expanded list algorithms (any/all/sum/product/zip/etc.).

--- a/stdlib/result.lzscr
+++ b/stdlib/result.lzscr
@@ -20,8 +20,8 @@
 ~unwrap_or_else ~f = \(.Ok ~x) -> ~x | \(.Err ~e) -> (~f ~e);
 
 # is_ok / is_err
-~is_ok = \(.Ok _) -> ~true | \(.Err _) -> ~false;
-~is_err = \(.Ok _) -> ~false | \(.Err _) -> ~true;
+~is_ok = \(.Ok _) -> .True | \(.Err _) -> .False;
+~is_err = \(.Ok _) -> .False | \(.Err _) -> .True;
 
 # to_option : Result a e -> Option a
 ~to_option = \(.Ok ~x) -> .Some ~x | \(.Err _) -> .None;


### PR DESCRIPTION
Removes the primitive Bool across the language and replaces it with the canonical union (.False | .True).\n\nKey changes:\n- Delete Type::Bool / Value::Bool / IrValue::Bool variants\n- Introduce bool_sum_type() for canonical union; update all prelude schemes\n- Runtime ops (logic/comparison/equality/char-class/eof) emit ctor values\n- Analyzer / CLI / CoreIR updated; pattern/value Bool arms removed\n- Printing currently shows .True/.False (pretty sugar 'Bool' deferred)\n- CI: add nightly cargo-udeps job (non-blocking)\n- License policy: prune unused allowlist entries in deny.toml\n- Docs & stdlib updated to reflect constructor-based booleans\n\nFollow-ups (not in this PR):\n- Pretty printer sugar (.False | .True -> Bool)\n- Potential IR specialization for booleans\n\nLet me know if you'd like those in this PR instead.